### PR TITLE
Include immediate children when caluclating scatter root's Aabb

### DIFF
--- a/src/scatter/systems/setup.rs
+++ b/src/scatter/systems/setup.rs
@@ -30,7 +30,7 @@ pub fn setup_root_aabb(
     for (root_entity, children) in &q_root {
         let aabb: Option<Aabb> = children
             .iter()
-            .flat_map(|child| q_children.iter_descendants(child))
+            .flat_map(|child| std::iter::once(child).chain(q_children.iter_descendants(child)))
             .filter_map(|entity| q_aabb.get(entity).ok())
             .fold(None, |aabb, child| {
                 aabb.map(|aabb| combine_aabbs(&aabb, child))


### PR DESCRIPTION
That's a small bug, but it got me real good !

Basically, it skipped Aabb for:
```
ScatterRoot
⤷ Mesh3d / Aabb
```
but worked for:
```
ScatterRoot
⤷ Entity
    ⤷ Mesh3d / Aabb
```