### PR TITLE
chore: release v0.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.12](https://github.com/NicoZweifel/bevy_feronia/compare/v0.5.11...v0.5.12) - 2026-01-03
+
+### Other
+
+- format

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_feronia"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "avian3d",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_feronia"
-version = "0.5.11"
+version = "0.5.12"
 
 edition = "2024"
 description = "Foliage/grass scattering tools and wind simulation shaders/materials that prioritize visual fidelity/artistic freedom, a declarative api and modularity."


### PR DESCRIPTION



## 🤖 New release

* `bevy_feronia`: 0.5.11 -> 0.5.12 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.12](https://github.com/NicoZweifel/bevy_feronia/compare/v0.5.11...v0.5.12) - 2026-01-03

### Other

- format
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).