### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/NicoZweifel/bevy_feronia/compare/v0.7.0...v0.7.1) - 2026-02-05
+
+### Added
+
+- trigger 0.8.0 && docs ([#89](https://github.com/NicoZweifel/bevy_feronia/pull/89))
+
+### Other
+
+- *(deps)* bump the dependencies group with 25 updates ([#87](https://github.com/NicoZweifel/bevy_feronia/pull/87))
+
 ## [0.5.12](https://github.com/NicoZweifel/bevy_feronia/compare/v0.5.11...v0.5.12) - 2026-01-06
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_feronia"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "avian3d",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_feronia"
-version = "0.7.0"
+version = "0.7.1"
 
 edition = "2024"
 description = "Foliage/grass scattering tools and wind simulation shaders/materials that prioritize visual fidelity/artistic freedom, a declarative api and modularity."


### PR DESCRIPTION



## 🤖 New release

* `bevy_feronia`: 0.7.0 -> 0.7.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.1](https://github.com/NicoZweifel/bevy_feronia/compare/v0.7.0...v0.7.1) - 2026-02-05

### Added

- trigger 0.8.0 && docs ([#89](https://github.com/NicoZweifel/bevy_feronia/pull/89))

### Other

- *(deps)* bump the dependencies group with 25 updates ([#87](https://github.com/NicoZweifel/bevy_feronia/pull/87))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).