### PR TITLE
chore: release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/NicoZweifel/bevy_feronia/compare/v0.8.1...v0.8.2) - 2026-02-20
+
+### Added
+
+- lots of fixes / improvements / learnings ([#93](https://github.com/NicoZweifel/bevy_feronia/pull/93))
+
+### Other
+
+- Update example.rs
+- Update Cargo.lock
+- cleanup cargo toml
+
 ## [0.8.1](https://github.com/NicoZweifel/bevy_feronia/compare/v0.8.0...v0.8.1) - 2026-02-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_feronia"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "avian3d",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_feronia"
-version = "0.8.1"
+version = "0.8.2"
 
 edition = "2024"
 description = "Foliage/grass scattering tools and wind simulation shaders/materials that prioritize visual fidelity/artistic freedom, a declarative api and modularity."


### PR DESCRIPTION



## 🤖 New release

* `bevy_feronia`: 0.8.1 -> 0.8.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.2](https://github.com/NicoZweifel/bevy_feronia/compare/v0.8.1...v0.8.2) - 2026-02-20

### Added

- lots of fixes / improvements / learnings ([#93](https://github.com/NicoZweifel/bevy_feronia/pull/93))

### Other

- Update example.rs
- Update Cargo.lock
- cleanup cargo toml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).