### PR TITLE
chore: release v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3](https://github.com/NicoZweifel/bevy_feronia/compare/v0.8.2...v0.8.3) - 2026-06-03
+
+### Fixed
+
+- fix ci badge
+- fix clippy
+
+### Other
+
+- Update EXAMPLES.md ([#101](https://github.com/NicoZweifel/bevy_feronia/pull/101))
+- Update handle_scatter_requests.rs
+- Update handle_scatter_requests.rs
+- save
+- Update lib.rs
+
 ## [0.8.2](https://github.com/NicoZweifel/bevy_feronia/compare/v0.8.1...v0.8.2) - 2026-02-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_feronia"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "avian3d",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_feronia"
-version = "0.8.2"
+version = "0.8.3"
 
 edition = "2024"
 description = "Foliage/grass scattering tools and wind simulation shaders/materials that prioritize visual fidelity/artistic freedom, a declarative api and modularity."


### PR DESCRIPTION



## 🤖 New release

* `bevy_feronia`: 0.8.2 -> 0.8.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.3](https://github.com/NicoZweifel/bevy_feronia/compare/v0.8.2...v0.8.3) - 2026-06-03

### Fixed

- fix ci badge
- fix clippy

### Other

- Update EXAMPLES.md ([#101](https://github.com/NicoZweifel/bevy_feronia/pull/101))
- Update handle_scatter_requests.rs
- Update handle_scatter_requests.rs
- save
- Update lib.rs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).