### PR TITLE
`DisablePrepass` component for instanced material

### DIFF
--- a/src/core/components.rs
+++ b/src/core/components.rs
@@ -46,6 +46,13 @@ impl LevelOfDetail {
 #[reflect(Component, Clone, Debug)]
 pub struct EnableDebug;
 
+/// Marker component to disable the normal/depth prepass for this scatter layer.
+///
+/// Only supported with [`InstancedWindAffectedMaterial`].
+#[derive(Component, Clone, Debug, Reflect, Default)]
+#[reflect(Component, Clone, Debug)]
+pub struct DisablePrepass;
+
 /// Marker component to make instances always face the camera.
 ///
 /// Enables `#ifdef BILLBOARDING` in shaders.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -69,6 +69,7 @@ pub struct MaterialOptionData {
     // General
     pub enable_debug: Option<&'static EnableDebug>,
     pub gpu_cull: Option<&'static GpuCullCompute>,
+    pub disable_prepass: Option<&'static DisablePrepass>,
 
     // Geometry
     pub enable_billboarding: Option<&'static EnableBillboarding>,
@@ -121,6 +122,7 @@ pub type MaterialChangedFilter = Or<(
     Or<(
         Changed<EnableDebug>,
         Changed<GpuCullCompute>,
+        Changed<DisablePrepass>,
         Changed<EnableBillboarding>,
         Changed<WindAffected>,
         Changed<LowQuality>,

--- a/src/core/options/general.rs
+++ b/src/core/options/general.rs
@@ -10,6 +10,7 @@ pub struct GeneralOptions {
     pub debug: bool,
     pub debug_color: Color,
     pub gpu_cull: bool,
+    pub disable_prepass: bool,
 }
 
 impl GeneralOptions {
@@ -17,6 +18,7 @@ impl GeneralOptions {
         Self {
             debug: data.enable_debug.is_some(),
             gpu_cull: data.gpu_cull.is_some(),
+            disable_prepass: data.disable_prepass.is_some(),
             ..default()
         }
     }
@@ -24,12 +26,14 @@ impl GeneralOptions {
     pub fn with_data(mut self, data: &MaterialOptionDataItem) -> Self {
         self.debug |= data.enable_debug.is_some();
         self.gpu_cull |= data.gpu_cull.is_some();
+        self.disable_prepass |= data.disable_prepass.is_some();
         self
     }
 
     pub fn with(mut self, other: Self) -> Self {
         self.debug |= other.debug;
         self.gpu_cull |= other.gpu_cull;
+        self.disable_prepass |= other.disable_prepass;
         self.controlled = other.controlled;
         if other.debug_color != Color::default() {
             self.debug_color = other.debug_color;

--- a/src/core/options/general.rs
+++ b/src/core/options/general.rs
@@ -85,6 +85,7 @@ mod tests {
             gpu_cull: true,
             controlled: true,         // Overwrite
             debug_color: BLUE.into(), // Overwrite
+            disable_prepass: false,
         };
 
         // Act

--- a/src/instancing/material.rs
+++ b/src/instancing/material.rs
@@ -39,7 +39,7 @@ impl InstancedWindAffectedMaterial {
             aabb: properties.aabb,
             options: properties.options.clone(),
             noise_texture,
-            disable_prepass: false,
+            disable_prepass: properties.options.general.disable_prepass,
         }
     }
 }

--- a/src/instancing/scatter.rs
+++ b/src/instancing/scatter.rs
@@ -58,6 +58,7 @@ impl ScatterMaterial for InstancedWindAffectedMaterial {
         {
             material.current = current_wind;
             material.previous = previous_wind;
+            material.disable_prepass = options.general.disable_prepass;
             material.options = options;
         }
     }


### PR DESCRIPTION
Just a user facing API to disable prepass for instanced grass. It works, I used to just hard-code it, figured it would be better to have a component for that.