### PR TITLE
chore: release v0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.5](https://github.com/NicoZweifel/bevy_feronia/compare/v0.8.4...v0.8.5) - 2026-08-20
+
+### Fixed
+
+- fix examples
+
+### Other
+
+- Merge branch 'dev' of https://github.com/NicoZweifel/bevy_feronia into dev
+- `DisablePrepass` component for instanced material ([#105](https://github.com/NicoZweifel/bevy_feronia/pull/105))
+
 ## [0.8.3](https://github.com/NicoZweifel/bevy_feronia/compare/v0.8.2...v0.8.3) - 2026-06-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_feronia"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "avian3d",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_feronia"
-version = "0.8.4"
+version = "0.8.5"
 
 edition = "2024"
 description = "Foliage/grass scattering tools and wind simulation shaders/materials that prioritize visual fidelity/artistic freedom, a declarative api and modularity."


### PR DESCRIPTION



## 🤖 New release

* `bevy_feronia`: 0.8.4 -> 0.8.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.5](https://github.com/NicoZweifel/bevy_feronia/compare/v0.8.4...v0.8.5) - 2026-08-20

### Fixed

- fix examples

### Other

- Merge branch 'dev' of https://github.com/NicoZweifel/bevy_feronia into dev
- `DisablePrepass` component for instanced material ([#105](https://github.com/NicoZweifel/bevy_feronia/pull/105))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).